### PR TITLE
Changed to KickClient and added kick msg

### DIFF
--- a/sourcemod/scripting/lagbotkicker.sp
+++ b/sourcemod/scripting/lagbotkicker.sp
@@ -17,7 +17,7 @@ public void HttpResponseCallback(bool success, const char[] error, System2HTTPRe
 						char sId[64];
 						GetClientAuthId(iPlayer,AuthId_SteamID64,sId,64);
 						if(StrEqual(sId,sBuffers[1])){
-							KickClientEx(iPlayer);
+							KickClient(iPlayer, "You need to finish setting up your steam profile to join this server.");
 						}
 					}
 				}


### PR DESCRIPTION
Using KickClient instead of KickClientEx is safer.

Notify users why they were kicked will make sure innocent users know why they were kicked